### PR TITLE
Geometry class refactoring to increase type-safety

### DIFF
--- a/src/javascript/Geometries/AreaFenceGeometry.js
+++ b/src/javascript/Geometries/AreaFenceGeometry.js
@@ -1,10 +1,11 @@
 import * as THREE from 'three'
 
 // AreaFenceGeometry
-class AreaFenceGeometry
+class AreaFenceGeometry extends THREE.BufferGeometry
 {
     constructor(_width, _height, _depth,)
     {
+        super();
         // Parameters
         this.parameters = {
             width: _width,
@@ -113,16 +114,12 @@ class AreaFenceGeometry
         indices[7 * 3 + 1] = 0
         indices[7 * 3 + 2] = 7
 
-        const geometry = new THREE.BufferGeometry()
-
         // Set indices
-        geometry.setIndex(new THREE.BufferAttribute(indices, 1, false))
+        this.setIndex(new THREE.BufferAttribute(indices, 1, false))
 
         // Set attributes
-        geometry.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3))
-        geometry.setAttribute('uv', new THREE.Float32BufferAttribute(uvs, 2))
-
-        return geometry
+        this.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3))
+        this.setAttribute('uv', new THREE.Float32BufferAttribute(uvs, 2))
     }
 }
 

--- a/src/javascript/Geometries/AreaFloorBorderBufferGeometry.js
+++ b/src/javascript/Geometries/AreaFloorBorderBufferGeometry.js
@@ -1,9 +1,10 @@
 import * as THREE from 'three'
 
-class AreaFloorBorderBufferGeometry
+class AreaFloorBorderBufferGeometry extends THREE.BufferGeometry
 {
     constructor(_width, _height, _thickness)
     {
+        super();
         // Parameters
         this.parameters = {
             width: _width,
@@ -92,15 +93,11 @@ class AreaFloorBorderBufferGeometry
         indices[7 * 3 + 1] = 4
         indices[7 * 3 + 2] = 7
 
-        const geometry = new THREE.BufferGeometry()
-
         // Set indices
-        geometry.setIndex(new THREE.BufferAttribute(indices, 1, false))
+        this.setIndex(new THREE.BufferAttribute(indices, 1, false))
 
         // Set attributes
-        geometry.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3))
-
-        return geometry
+        this.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3))
     }
 }
 

--- a/src/javascript/Geometries/AreaFloorBorderGeometry.js
+++ b/src/javascript/Geometries/AreaFloorBorderGeometry.js
@@ -1,9 +1,10 @@
 import * as THREE from 'three'
 
-class AreaFloorBorderGeometry
+class AreaFloorBorderGeometry extends THREE.BufferGeometry
 {
     constructor(_width, _height, _thickness)
     {
+        super();
         // Parameters
         this.parameters = {
             width: _width,
@@ -92,15 +93,11 @@ class AreaFloorBorderGeometry
         indices[7 * 3 + 1] = 4
         indices[7 * 3 + 2] = 7
 
-        const geometry = new THREE.BufferGeometry()
-
         // Set indices
-        geometry.setIndex(new THREE.BufferAttribute(indices, 1, false))
+        this.setIndex(new THREE.BufferAttribute(indices, 1, false))
 
         // Set attributes
-        geometry.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3))
-
-        return geometry
+        this.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3))
     }
 }
 


### PR DESCRIPTION
**`AreaFloorBorderGeometry`**
**`AreaFenceGeometry`**

- This refactor follows the latest Threejs patterns
- Property `parameters` does not exist on `BufferGeometry` and returning a `BoxGeometry` in the constructor causes incorrect type exporting.
- The previous code will throw an error in TypeScript